### PR TITLE
feat: enable emails by default when creating subscription

### DIFF
--- a/common/src/subscriptions.ts
+++ b/common/src/subscriptions.ts
@@ -9,7 +9,7 @@ const allMessageTypes = Object.values(NotificationType).reduce(
 )
 
 const _defaultSubscription: SubscriptionDetails = {
-  ignore_all_email: true,
+  ignore_all_email: false,
   ignore_all_in_app: false,
   message_type: allMessageTypes
 }


### PR DESCRIPTION
# Changes
This change allows default subscriptions to start with all emails enabled when a user validates their email.