### PR TITLE
feat: add custom params as argument in sendgrid client sendEmail

### DIFF
--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -60,5 +60,4 @@ export type Email = {
     type: string
     disposition: string
   }[]
-  tracking_id?: string
 }

--- a/common/test/unit/adapters/sendgrid-client.spec.ts
+++ b/common/test/unit/adapters/sendgrid-client.spec.ts
@@ -46,9 +46,9 @@ describe('sendgrid client tests', () => {
           type: 'text/html',
           disposition: 'inline'
         }
-      ],
-      tracking_id: '1234'
+      ]
     }
+
     await sendGridClient.sendEmail(email, {
       environment: 'test',
       tracking_id: '1234'

--- a/common/test/unit/adapters/sendgrid-client.spec.ts
+++ b/common/test/unit/adapters/sendgrid-client.spec.ts
@@ -49,7 +49,10 @@ describe('sendgrid client tests', () => {
       ],
       tracking_id: '1234'
     }
-    await sendGridClient.sendEmail(email)
+    await sendGridClient.sendEmail(email, {
+      environment: 'test',
+      tracking_id: '1234'
+    })
 
     expect(fetch.fetch).toHaveBeenCalledWith('https://api.sendgrid.com/v3/mail/send', {
       body: JSON.stringify({
@@ -92,7 +95,9 @@ describe('sendgrid client tests', () => {
       subject: 'This is a subject',
       content: 'This is the content'
     }
-    await sendGridClient.sendEmail(email)
+    await sendGridClient.sendEmail(email, {
+      environment: 'test'
+    })
 
     expect(fetch.fetch).toHaveBeenCalledWith('https://api.sendgrid.com/v3/mail/send', {
       body: JSON.stringify({

--- a/inbox/src/controllers/handlers/unconfirmed-email-handlers.ts
+++ b/inbox/src/controllers/handlers/unconfirmed-email-handlers.ts
@@ -17,6 +17,7 @@ export async function storeUnconfirmedEmailHandler(
   const { config, dataWarehouseClient, db, emailRenderer, sendGridClient } = context.components
 
   const address = context.verification!.auth
+  const env = await config.requireString('ENV')
 
   const body = await parseJson<{ email: string }>(context.request)
   if (body.email !== '' && !Email.validate(body.email)) {
@@ -42,7 +43,10 @@ export async function storeUnconfirmedEmailHandler(
         validateButtonText: 'Click Here to Confirm Your Email'
       }))
     }
-    await sendGridClient.sendEmail(email)
+    await sendGridClient.sendEmail(email, {
+      environment: env,
+      email_type: 'validation_attempt'
+    })
     await dataWarehouseClient.sendEvent({
       context: 'notification_server',
       event: 'email_validation_started',

--- a/processor/src/adapters/email-renderer.ts
+++ b/processor/src/adapters/email-renderer.ts
@@ -85,8 +85,7 @@ export async function createEmailRenderer(components: Pick<AppComponents, 'confi
       content: templates[notification.type][TemplatePart.CONTENT](notification),
       ...JSON.parse(templates[notification.type][TemplatePart.SUBJECT](notification)),
       unsubscribeAllUrl,
-      unsubscribeOneUrl,
-      tracking_id: notification.id
+      unsubscribeOneUrl
     }
   }
 

--- a/processor/src/adapters/notifications-service.ts
+++ b/processor/src/adapters/notifications-service.ts
@@ -6,7 +6,7 @@ export type INotificationsService = {
 }
 
 export async function createNotificationsService(
-  components: Pick<AppComponents, 'db' | 'emailRenderer' | 'logs' | 'sendGridClient' | 'subscriptionService' | 'config'>
+  components: Pick<AppComponents, 'config' | 'db' | 'emailRenderer' | 'logs' | 'sendGridClient' | 'subscriptionService'>
 ): Promise<INotificationsService> {
   const { db, emailRenderer, logs, sendGridClient, subscriptionService, config } = components
   const logger = logs.getLogger('notifications-service')

--- a/processor/src/components.ts
+++ b/processor/src/components.ts
@@ -75,6 +75,7 @@ export async function initComponents(): Promise<AppComponents> {
   const sendGridClient = await createSendGrid({ config, fetch, logs })
 
   const notificationsService = await createNotificationsService({
+    config,
     db,
     emailRenderer,
     logs,

--- a/processor/test/integration/publish-notification-handler.spec.ts
+++ b/processor/test/integration/publish-notification-handler.spec.ts
@@ -60,8 +60,7 @@ test('POST /notifications', function ({ components, stubComponents }) {
       subject: 'Access to Your Worlds Has Been Restored',
       content: '<p>Access to your Worlds has been restored.</p>\n',
       actionButtonText: 'Manage Worlds',
-      actionButtonLink: 'https://decentraland.org/builder/worlds?tab=dcl',
-      tracking_id: '123'
+      actionButtonLink: 'https://decentraland.org/builder/worlds?tab=dcl'
     }
     stubComponents.emailRenderer.renderEmail.withArgs(email, sinon.match(notification)).resolves(renderedEmail)
     stubComponents.sendGridClient.sendEmail.withArgs(renderedEmail).resolves()

--- a/processor/test/unit/adapters/__snapshots__/email-renderer.spec.ts.snap
+++ b/processor/test/unit/adapters/__snapshots__/email-renderer.spec.ts.snap
@@ -8,7 +8,6 @@ exports[`email rendering tests rendering bid_accepted 1`] = `
 ",
   "subject": "Your offer was accepted",
   "to": "email@example.com",
-  "tracking_id": "123456789",
   "unsubscribeAllUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678?signature=fd03dab02225f386464bdc0ea85ddffb0dd4ad1bc53e6be420224fd381cc58e5",
   "unsubscribeOneUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678/bid_accepted?signature=9ec6a41cd5d70f14ea3ce7f7bfc7278daa1de5627201aa5adeb7b60275e7197d",
 }
@@ -22,7 +21,6 @@ exports[`email rendering tests rendering bid_received 1`] = `
 ",
   "subject": "You've Received a Bid",
   "to": "email@example.com",
-  "tracking_id": "123456789",
   "unsubscribeAllUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678?signature=fd03dab02225f386464bdc0ea85ddffb0dd4ad1bc53e6be420224fd381cc58e5",
   "unsubscribeOneUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678/bid_received?signature=d5c3e6e4a1213edcbabd8293b60b109f4d583f896724af67f18d8e1ec0a39e2f",
 }
@@ -36,7 +34,6 @@ exports[`email rendering tests rendering events_started 1`] = `
 ",
   "subject": "Jump In - Your Event Has Started!",
   "to": "email@example.com",
-  "tracking_id": "123456789",
   "unsubscribeAllUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678?signature=fd03dab02225f386464bdc0ea85ddffb0dd4ad1bc53e6be420224fd381cc58e5",
   "unsubscribeOneUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678/events_started?signature=cd81b69793b500eed74735a88f2be42fa2bf419853b014165860c4304998feba",
 }
@@ -50,7 +47,6 @@ exports[`email rendering tests rendering events_starts_soon 1`] = `
 ",
   "subject": "An Event You've RSVP'd to Starts Soon",
   "to": "email@example.com",
-  "tracking_id": "123456789",
   "unsubscribeAllUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678?signature=fd03dab02225f386464bdc0ea85ddffb0dd4ad1bc53e6be420224fd381cc58e5",
   "unsubscribeOneUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678/events_starts_soon?signature=0477800e313b855d10038d850a7b7450cc86687adc863049450415611d1effe7",
 }
@@ -67,7 +63,6 @@ exports[`email rendering tests rendering governance_announcement 1`] = `
 ",
   "subject": "A DAO Announcement Has Been Released",
   "to": "email@example.com",
-  "tracking_id": "123456789",
   "unsubscribeAllUrl": "https://notifications.decentraland.org/unsubscribe/null?signature=42ad30f79fb01e2c2ae57f84f34ab8b6bff2b70bc7a9e900e021f0b1fa22e7a8",
   "unsubscribeOneUrl": "https://notifications.decentraland.org/unsubscribe/null/governance_announcement?signature=033e9737a5b20c9af782facf62c1e65d637469f20331172456337a0a9bbe492d",
 }
@@ -81,7 +76,6 @@ exports[`email rendering tests rendering governance_authored_proposal_finished 1
 ",
   "subject": "Voting Has Ended on Your Proposal",
   "to": "email@example.com",
-  "tracking_id": "123456789",
   "unsubscribeAllUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678?signature=fd03dab02225f386464bdc0ea85ddffb0dd4ad1bc53e6be420224fd381cc58e5",
   "unsubscribeOneUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678/governance_authored_proposal_finished?signature=f1ca8c3fd6f39383aa205367335ba70df4f017d676302557ef76b3c37c0eb8f4",
 }
@@ -95,7 +89,6 @@ exports[`email rendering tests rendering governance_coauthor_requested 1`] = `
 ",
   "subject": "You've Received a Request to Co-Author a Proposal",
   "to": "email@example.com",
-  "tracking_id": "123456789",
   "unsubscribeAllUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678?signature=fd03dab02225f386464bdc0ea85ddffb0dd4ad1bc53e6be420224fd381cc58e5",
   "unsubscribeOneUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678/governance_coauthor_requested?signature=ede0f5a009044402cfb42487e7c300f122b5047cb869f4ca4fca6ab4e715413b",
 }
@@ -109,7 +102,6 @@ exports[`email rendering tests rendering governance_new_comment_on_project_updat
 ",
   "subject": "There's a New Comment on Your Project Update",
   "to": "email@example.com",
-  "tracking_id": "123456789",
   "unsubscribeAllUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678?signature=fd03dab02225f386464bdc0ea85ddffb0dd4ad1bc53e6be420224fd381cc58e5",
   "unsubscribeOneUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678/governance_new_comment_on_project_update?signature=e2199b81d0ba406972576521fca39817b82720c1221bbfd17427495e8b1b35e3",
 }
@@ -123,7 +115,6 @@ exports[`email rendering tests rendering governance_new_comment_on_proposal 1`] 
 ",
   "subject": "There's a New Comment on Your Proposal",
   "to": "email@example.com",
-  "tracking_id": "123456789",
   "unsubscribeAllUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678?signature=fd03dab02225f386464bdc0ea85ddffb0dd4ad1bc53e6be420224fd381cc58e5",
   "unsubscribeOneUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678/governance_new_comment_on_proposal?signature=8aac2dc2f0e423b34fa237c2f780678db04317f546f846612c81f8b785ad1be2",
 }
@@ -137,7 +128,6 @@ exports[`email rendering tests rendering governance_pitch_passed 1`] = `
 ",
   "subject": "A Pitch You Voted on Has Passed",
   "to": "email@example.com",
-  "tracking_id": "123456789",
   "unsubscribeAllUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678?signature=fd03dab02225f386464bdc0ea85ddffb0dd4ad1bc53e6be420224fd381cc58e5",
   "unsubscribeOneUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678/governance_pitch_passed?signature=f62cdb39ed30d32ffcf6304ca423bbef4a15f72d2e75066f8013ef9d639cfe39",
 }
@@ -151,7 +141,6 @@ exports[`email rendering tests rendering governance_proposal_enacted 1`] = `
 ",
   "subject": "Your Proposal's Been Enacted!",
   "to": "email@example.com",
-  "tracking_id": "123456789",
   "unsubscribeAllUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678?signature=fd03dab02225f386464bdc0ea85ddffb0dd4ad1bc53e6be420224fd381cc58e5",
   "unsubscribeOneUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678/governance_proposal_enacted?signature=f3dfdad5828adce10d2dbd465c15a6abe00cce0bd743cd5672a206fb331101a2",
 }
@@ -165,7 +154,6 @@ exports[`email rendering tests rendering governance_tender_passed 1`] = `
 ",
   "subject": "A Tender You Voted on Has Passed",
   "to": "email@example.com",
-  "tracking_id": "123456789",
   "unsubscribeAllUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678?signature=fd03dab02225f386464bdc0ea85ddffb0dd4ad1bc53e6be420224fd381cc58e5",
   "unsubscribeOneUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678/governance_tender_passed?signature=55f54b9574722ae7e44aa32dab3c1c941dd5ebe6684f0dae6f963419ac1afd58",
 }
@@ -179,7 +167,6 @@ exports[`email rendering tests rendering governance_voting_ended_voter 1`] = `
 ",
   "subject": "Voting Has Ended on a Proposal You Voted On",
   "to": "email@example.com",
-  "tracking_id": "123456789",
   "unsubscribeAllUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678?signature=fd03dab02225f386464bdc0ea85ddffb0dd4ad1bc53e6be420224fd381cc58e5",
   "unsubscribeOneUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678/governance_voting_ended_voter?signature=b990e4bad77532500c9cb86bdfd0ed47fc22e5f4dba9733be46ab2de4a896481",
 }
@@ -193,7 +180,6 @@ exports[`email rendering tests rendering item_sold 1`] = `
 ",
   "subject": "You've Sold an Item!",
   "to": "email@example.com",
-  "tracking_id": "123456789",
   "unsubscribeAllUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678?signature=fd03dab02225f386464bdc0ea85ddffb0dd4ad1bc53e6be420224fd381cc58e5",
   "unsubscribeOneUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678/item_sold?signature=9d39adb74e120e5abcfd5803e621ae2e80fc716d10f171f73bf011a3f6da8a02",
 }
@@ -207,7 +193,6 @@ exports[`email rendering tests rendering rental_ended 1`] = `
 ",
   "subject": "Rental Period Ended",
   "to": "email@example.com",
-  "tracking_id": "123456789",
   "unsubscribeAllUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678?signature=fd03dab02225f386464bdc0ea85ddffb0dd4ad1bc53e6be420224fd381cc58e5",
   "unsubscribeOneUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678/rental_ended?signature=21a703f932c6e5610468c1d2f2131fe14699976425529b407452769cab6b56ab",
 }
@@ -221,7 +206,6 @@ exports[`email rendering tests rendering rental_started 1`] = `
 ",
   "subject": "Your LAND Has Been Rented",
   "to": "email@example.com",
-  "tracking_id": "123456789",
   "unsubscribeAllUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678?signature=fd03dab02225f386464bdc0ea85ddffb0dd4ad1bc53e6be420224fd381cc58e5",
   "unsubscribeOneUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678/rental_started?signature=32ef3d8ee29b758d9822c2efc5d62873c015d414ab6740e01a92329725dc6114",
 }
@@ -235,7 +219,6 @@ exports[`email rendering tests rendering reward_assignment 1`] = `
 ",
   "subject": "You've Received a Free Item!",
   "to": "email@example.com",
-  "tracking_id": "123456789",
   "unsubscribeAllUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678?signature=fd03dab02225f386464bdc0ea85ddffb0dd4ad1bc53e6be420224fd381cc58e5",
   "unsubscribeOneUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678/reward_assignment?signature=f0e7a9b4fbf803375b4148cd23f4a07fd84d89b37c91bd1df6b53b1d3d90da32",
 }
@@ -249,7 +232,6 @@ exports[`email rendering tests rendering royalties_earned 1`] = `
 ",
   "subject": "You've Earned Some Royalties!",
   "to": "email@example.com",
-  "tracking_id": "123456789",
   "unsubscribeAllUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678?signature=fd03dab02225f386464bdc0ea85ddffb0dd4ad1bc53e6be420224fd381cc58e5",
   "unsubscribeOneUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678/royalties_earned?signature=959d803e1bb8bc4e45820c6e2b82184654968fffb6bae1f6380fbef04a96e0fe",
 }
@@ -263,7 +245,6 @@ exports[`email rendering tests rendering worlds_access_restored 1`] = `
 ",
   "subject": "Access to Your Worlds Has Been Restored",
   "to": "email@example.com",
-  "tracking_id": "123456789",
   "unsubscribeAllUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678?signature=fd03dab02225f386464bdc0ea85ddffb0dd4ad1bc53e6be420224fd381cc58e5",
   "unsubscribeOneUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678/worlds_access_restored?signature=aeb5c56796a62bda50e2156422fa41c2560afd22268b5a90b9c34609fc6bc3e5",
 }
@@ -278,7 +259,6 @@ exports[`email rendering tests rendering worlds_access_restricted 1`] = `
 ",
   "subject": "Access to Your Worlds Has Been Restricted",
   "to": "email@example.com",
-  "tracking_id": "123456789",
   "unsubscribeAllUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678?signature=fd03dab02225f386464bdc0ea85ddffb0dd4ad1bc53e6be420224fd381cc58e5",
   "unsubscribeOneUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678/worlds_access_restricted?signature=5e65d8cf2afa3afbc02d9d175b8c5b139312dc80ec1d5e6a79c91662c9918cc8",
 }
@@ -293,7 +273,6 @@ exports[`email rendering tests rendering worlds_missing_resources 1`] = `
 ",
   "subject": "[Action Needed] Insufficient World Storage",
   "to": "email@example.com",
-  "tracking_id": "123456789",
   "unsubscribeAllUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678?signature=fd03dab02225f386464bdc0ea85ddffb0dd4ad1bc53e6be420224fd381cc58e5",
   "unsubscribeOneUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678/worlds_missing_resources?signature=d65886c8b10069f5d1355a2b05199b2059b7e0a48049a1d6531fcbb9d3398eb6",
 }
@@ -307,7 +286,6 @@ exports[`email rendering tests rendering worlds_permission_granted 1`] = `
 ",
   "subject": "You've Been Granted New World Permissions",
   "to": "email@example.com",
-  "tracking_id": "123456789",
   "unsubscribeAllUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678?signature=fd03dab02225f386464bdc0ea85ddffb0dd4ad1bc53e6be420224fd381cc58e5",
   "unsubscribeOneUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678/worlds_permission_granted?signature=807e16ba5e0d7d196158bcc4e02d49d8f26ee6cd4d6b321e0be3b6bfe096799d",
 }
@@ -321,7 +299,6 @@ exports[`email rendering tests rendering worlds_permission_revoked 1`] = `
 ",
   "subject": "You've Had World Permissions Revoked",
   "to": "email@example.com",
-  "tracking_id": "123456789",
   "unsubscribeAllUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678?signature=fd03dab02225f386464bdc0ea85ddffb0dd4ad1bc53e6be420224fd381cc58e5",
   "unsubscribeOneUrl": "https://notifications.decentraland.org/unsubscribe/0x1234567890ABCDEF1234567890ABCDEF12345678/worlds_permission_revoked?signature=11ecba1cbdb390cf8ea1cd5e13d746d8c7a1f918a2c3e5d641a03b6269176ba6",
 }

--- a/processor/test/unit/adapters/email-renderer.spec.ts
+++ b/processor/test/unit/adapters/email-renderer.spec.ts
@@ -6,7 +6,8 @@ import { NotificationRecord } from '@notifications/common'
 describe('email rendering tests', () => {
   let config = createConfigComponent({
     SIGNING_KEY: 'some-super-secret-key',
-    SERVICE_BASE_URL: 'https://notifications.decentraland.org'
+    SERVICE_BASE_URL: 'https://notifications.decentraland.org',
+    ENV: 'test'
   })
   let renderer: IEmailRenderer
 


### PR DESCRIPTION
This PR allows sendgrid client `sendEmail` API to receive custom arguments from the caller. This allows to further customize the params according who's calling.

This feature was added since we need to identify different emails such as `Validation` emails or `Notification` emails in Sendgrid's webhooks request for tracking purposes.