### PR TITLE
feat: endpoint to retrieve self registered email

### DIFF
--- a/inbox/src/controllers/handlers/get-subscription-handler.ts
+++ b/inbox/src/controllers/handlers/get-subscription-handler.ts
@@ -1,9 +1,27 @@
 import { HandlerContextWithPath } from '../../types'
 import { IHttpServerComponent } from '@well-known-components/interfaces'
-import { Subscription } from '@dcl/schemas'
+import { EthAddress, Subscription, SubscriptionDetails } from '@dcl/schemas'
+import { InvalidRequestError } from '@dcl/platform-server-commons'
+import { DbComponent } from '@notifications/common'
 
 type SubscriptionResponse = Subscription & {
   unconfirmedEmail: string | undefined
+}
+
+async function getSubscription(
+  address: EthAddress,
+  db: DbComponent
+): Promise<{ email: string | undefined; unconfirmedEmail: string | undefined; details: SubscriptionDetails }> {
+  const [subscription, unconfirmedEmail] = await Promise.all([
+    db.findSubscription(address),
+    db.findUnconfirmedEmail(address)
+  ])
+
+  return {
+    email: subscription.email,
+    unconfirmedEmail: unconfirmedEmail?.email,
+    details: subscription.details
+  }
 }
 
 export async function getSubscriptionHandler(
@@ -12,16 +30,28 @@ export async function getSubscriptionHandler(
   const { db } = context.components
 
   const address = context.verification!.auth
-  const [subscription, unconfirmedEmail] = await Promise.all([
-    db.findSubscription(address),
-    db.findUnconfirmedEmail(address)
-  ])
+  const subscription = await getSubscription(address, db)
 
   return {
-    body: {
-      email: subscription.email,
-      unconfirmedEmail: unconfirmedEmail?.email,
-      details: subscription.details
-    } as SubscriptionResponse
+    body: subscription as SubscriptionResponse
+  }
+}
+
+export async function getSubscriptionAsAdminHandler(
+  context: Pick<HandlerContextWithPath<'db' | 'logs', '/subscription/:address'>, 'url' | 'components' | 'params'>
+): Promise<IHttpServerComponent.IResponse> {
+  const {
+    components: { db },
+    params: { address }
+  } = context
+
+  if (!EthAddress.validate(address)) {
+    throw new InvalidRequestError('Invalid address')
+  }
+
+  const subscription = await getSubscription(address, db)
+
+  return {
+    body: subscription as SubscriptionResponse
   }
 }

--- a/inbox/src/controllers/routes.ts
+++ b/inbox/src/controllers/routes.ts
@@ -1,11 +1,11 @@
 import { Router } from '@well-known-components/http-server'
 import { statusHandler } from './handlers/status-handler'
 import { notificationsHandler } from './handlers/notifications-handler'
-import { errorHandler, NotAuthorizedError } from '@dcl/platform-server-commons'
+import { bearerTokenMiddleware, errorHandler, NotAuthorizedError } from '@dcl/platform-server-commons'
 import { wellKnownComponents } from '@dcl/platform-crypto-middleware'
 import { GlobalContext } from '../types'
 import { readNotificationsHandler } from './handlers/read-notifications-handler'
-import { getSubscriptionHandler } from './handlers/get-subscription-handler'
+import { getSubscriptionAsAdminHandler, getSubscriptionHandler } from './handlers/get-subscription-handler'
 import { putSubscriptionHandler } from './handlers/put-subscription-handler'
 import { confirmEmailHandler, storeUnconfirmedEmailHandler } from './handlers/unconfirmed-email-handlers'
 import { unsubscribeAllHandler, unsubscribeOneHandler } from './handlers/unsubscription-handlers'
@@ -21,6 +21,7 @@ export async function setupRouter({ components }: GlobalContext): Promise<Router
   const { config, fetch } = components
 
   const signingKey = await config.requireString('SIGNING_KEY')
+  const adminApiKey = await config.requireString('ADMIN_API_KEY')
 
   const signedFetchMiddleware = wellKnownComponents({
     fetcher: fetch,
@@ -58,6 +59,8 @@ export async function setupRouter({ components }: GlobalContext): Promise<Router
 
   router.put('/set-email', signedFetchMiddleware, storeUnconfirmedEmailHandler)
   router.put('/confirm-email', confirmEmailHandler)
+
+  router.get('/subscription/:address', bearerTokenMiddleware(adminApiKey), getSubscriptionAsAdminHandler)
 
   return router
 }


### PR DESCRIPTION
This PR exposes a secured endpoint (_restricted by `Admin API Key` to perform service-to-service calls_) to retrieve self-registered email so it can be re-used by other services demanding email integration like `credits`.